### PR TITLE
feat: add sd-jwt issuer support and e2e test

### DIFF
--- a/packages/callback-example/lib/IssuerCallback.ts
+++ b/packages/callback-example/lib/IssuerCallback.ts
@@ -4,7 +4,8 @@ import { Ed25519VerificationKey2020 } from '@digitalcredentials/ed25519-verifica
 import { securityLoader } from '@digitalcredentials/security-document-loader'
 import vc from '@digitalcredentials/vc'
 import { CredentialRequestV1_0_11 } from '@sphereon/oid4vci-common'
-import { ICredential, W3CVerifiableCredential } from '@sphereon/ssi-types'
+import { CredentialIssuanceInput } from '@sphereon/oid4vci-issuer'
+import { W3CVerifiableCredential } from '@sphereon/ssi-types'
 
 // Example on how to generate a did:key to issue a verifiable credential
 export const generateDid = async () => {
@@ -14,12 +15,12 @@ export const generateDid = async () => {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const getIssuerCallback = (credential: ICredential, keyPair: any, verificationMethod: string) => {
+export const getIssuerCallback = (credential: CredentialIssuanceInput, keyPair: any, verificationMethod: string) => {
   if (!credential) {
     throw new Error('A credential needs to be provided')
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return async (_opts: { credentialRequest?: CredentialRequestV1_0_11; credential?: ICredential }): Promise<W3CVerifiableCredential> => {
+  return async (_opts: { credentialRequest?: CredentialRequestV1_0_11; credential?: CredentialIssuanceInput }): Promise<W3CVerifiableCredential> => {
     const documentLoader = securityLoader().build()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const verificationKey: any = Array.from(keyPair.values())[0]

--- a/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
+++ b/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
@@ -167,7 +167,7 @@ describe('issuerCallback', () => {
       )
       .withCredentialSignerCallback((opts) =>
         Promise.resolve({
-          ...opts.credential,
+          ...(opts.credential as ICredential),
           proof: {
             type: IProofType.JwtProof2020,
             jwt: 'ye.ye.ye',

--- a/packages/callback-example/package.json
+++ b/packages/callback-example/package.json
@@ -18,7 +18,7 @@
     "@sphereon/oid4vci-client": "workspace:*",
     "@sphereon/oid4vci-common": "workspace:*",
     "@sphereon/oid4vci-issuer": "workspace:*",
-    "@sphereon/ssi-types": "0.17.2",
+    "@sphereon/ssi-types": "0.17.6-unstable.69",
     "jose": "^4.10.0"
   },
   "devDependencies": {

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -72,12 +72,10 @@ console.log(client.getAccessTokenEndpoint()); // https://auth.research.identipro
 
 The OID4VCI Server metadata contains information about token endpoints, credential endpoints, as well as additional
 information about supported Credentials, and their cryptographic suites and formats.
-The code above already retrieved the metadata, so it will not be fetched again. If you however not used
+The code above already retrieved the metadata, so it will not be fetched again, and this method places the data in another variable. If you however have not used
 the `retrieveServerMetadata` option, you can use this method to fetch it from the Issuer:
 
 ```typescript
-import { OpenID4VCIClient } from '@sphereon/oid4vci-client';
-
 const metadata = await client.retrieveServerMetadata();
 ```
 
@@ -111,6 +109,8 @@ the [Proof of Posession](#proof-of-possession) chapter for more information.
 The Proof of Possession using a signature callback function. The example uses the `jose` library.
 
 ```typescript
+import * as jose from 'jose';
+
 const { privateKey, publicKey } = await jose.generateKeyPair('ES256');
 
 // Must be JWS
@@ -121,7 +121,7 @@ async function signCallback(args: Jwt, kid: string): Promise<string> {
     .setIssuer(kid)
     .setAudience(args.payload.aud)
     .setExpirationTime('2h')
-    .sign(keypair.privateKey);
+    .sign(privateKey);
 }
 
 const callbacks: ProofOfPossessionCallbacks = {
@@ -133,14 +133,14 @@ Now it is time to get the actual credential
 
 ```typescript
 const credentialResponse = await client.acquireCredentials({
-  credentialType: 'OpenBadgeCredential',
+  credentialTypes: 'OpenBadgeCredential',
   proofCallbacks: callbacks,
-  format: 'jwt_vc',
+  format: 'jwt_vc_json',
   alg: Alg.ES256K,
   kid: 'did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1',
 });
 console.log(credentialResponse.credential);
-// JWT format. (LDP/JSON-LD is also supported by the client)
+// JWT format. (LDP / JSON-LD ('ldp_vc' / 'jwt_vc_json-ld') is also supported by the client)
 // eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImlkIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzM3MzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly9leGFtcGxlLmVkdS9pc3N1ZXJzLzU2NTA0OSIsImlzc3VhbmNlRGF0ZSI6IjIwMTAtMDEtMDFUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19LCJpc3MiOiJodHRwczovL2V4YW1wbGUuZWR1L2lzc3VlcnMvNTY1MDQ5IiwibmJmIjoxMjYyMzA0MDAwLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsInN1YiI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJ9.z5vgMTK1nfizNCg5N-niCOL3WUIAL7nXy-nGhDZYO_-PNGeE-0djCpWAMH8fD8eWSID5PfkPBYkx_dfLJnQ7NA
 ```
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -110,6 +110,7 @@ The Proof of Possession using a signature callback function. The example uses th
 
 ```typescript
 import * as jose from 'jose';
+import { DIDDocument } from 'did-resolver';
 
 const { privateKey, publicKey } = await jose.generateKeyPair('ES256');
 
@@ -124,7 +125,7 @@ async function signCallback(args: Jwt, kid: string): Promise<string> {
     .sign(privateKey);
 }
 
-const callbacks: ProofOfPossessionCallbacks = {
+const callbacks: ProofOfPossessionCallbacks<DIDDocument> = {
   signCallback,
 };
 ```

--- a/packages/client/lib/CredentialRequestClient.ts
+++ b/packages/client/lib/CredentialRequestClient.ts
@@ -123,9 +123,7 @@ export class CredentialRequestClient {
       return {
         format,
         proof,
-        credential_definition: {
-          vct: types[0],
-        },
+        vct: types[0],
       };
     }
 

--- a/packages/client/lib/OpenID4VCIClient.ts
+++ b/packages/client/lib/OpenID4VCIClient.ts
@@ -411,8 +411,8 @@ export class OpenID4VCIClient {
           return [c];
         } else if ('types' in c) {
           return c.types;
-        } else if ('vct' in c.credential_definition) {
-          return [c.credential_definition.vct];
+        } else if ('vct' in c) {
+          return [c.vct];
         } else {
           return c.credential_definition.types;
         }

--- a/packages/client/lib/OpenID4VCIClient.ts
+++ b/packages/client/lib/OpenID4VCIClient.ts
@@ -9,6 +9,8 @@ import {
   CredentialSupported,
   EndpointMetadataResult,
   JsonURIMode,
+  JWK,
+  KID_JWK_X5C_ERROR,
   OID4VCICredentialFormat,
   OpenId4VCIVersion,
   ProofOfPossessionCallbacks,
@@ -49,6 +51,7 @@ export class OpenID4VCIClient {
   private readonly _credentialOffer: CredentialOfferRequestWithBaseUrl;
   private _clientId?: string;
   private _kid: string | undefined;
+  private _jwk: JWK | undefined;
   private _alg: Alg | string | undefined;
   private _endpointMetadata: EndpointMetadataResult | undefined;
   private _accessTokenResponse: AccessTokenResponse | undefined;
@@ -281,6 +284,7 @@ export class OpenID4VCIClient {
     proofCallbacks,
     format,
     kid,
+    jwk,
     alg,
     jti,
   }: {
@@ -288,15 +292,17 @@ export class OpenID4VCIClient {
     proofCallbacks: ProofOfPossessionCallbacks<any>;
     format?: CredentialFormat | OID4VCICredentialFormat;
     kid?: string;
+    jwk?: JWK;
     alg?: Alg | string;
     jti?: string;
   }): Promise<CredentialResponse> {
-    if (alg) {
-      this._alg = alg;
+    if ([jwk, kid].filter((v) => v !== undefined).length > 1) {
+      throw new Error(KID_JWK_X5C_ERROR + `. jwk: ${jwk !== undefined}, kid: ${kid !== undefined}`);
     }
-    if (kid) {
-      this._kid = kid;
-    }
+
+    if (alg) this._alg = alg;
+    if (jwk) this._jwk = jwk;
+    if (kid) this._kid = kid;
 
     const requestBuilder = CredentialRequestClientBuilder.fromCredentialOffer({
       credentialOffer: this.credentialOffer,
@@ -339,8 +345,14 @@ export class OpenID4VCIClient {
       version: this.version(),
     })
       .withIssuer(this.getIssuer())
-      .withAlg(this.alg)
-      .withKid(this.kid);
+      .withAlg(this.alg);
+
+    if (this._jwk) {
+      proofBuilder.withJWK(this._jwk);
+    }
+    if (this._kid) {
+      proofBuilder.withKid(this._kid);
+    }
 
     if (this.clientId) {
       proofBuilder.withClientId(this.clientId);

--- a/packages/client/lib/ProofOfPossessionBuilder.ts
+++ b/packages/client/lib/ProofOfPossessionBuilder.ts
@@ -2,6 +2,7 @@ import {
   AccessTokenResponse,
   Alg,
   EndpointMetadata,
+  JWK,
   Jwt,
   NO_JWT_PROVIDED,
   OpenId4VCIVersion,
@@ -19,6 +20,7 @@ export class ProofOfPossessionBuilder<DIDDoc> {
   private readonly version: OpenId4VCIVersion;
 
   private kid?: string;
+  private jwk?: JWK;
   private clientId?: string;
   private issuer?: string;
   private jwt?: Jwt;
@@ -88,6 +90,11 @@ export class ProofOfPossessionBuilder<DIDDoc> {
 
   withKid(kid: string): this {
     this.kid = kid;
+    return this;
+  }
+
+  withJWK(jwk: JWK): this {
+    this.jwk = jwk;
     return this;
   }
 
@@ -182,6 +189,7 @@ export class ProofOfPossessionBuilder<DIDDoc> {
         {
           typ: this.typ ?? (this.version < OpenId4VCIVersion.VER_1_0_11 ? 'jwt' : 'openid4vci-proof+jwt'),
           kid: this.kid,
+          jwk: this.jwk,
           jti: this.jti,
           alg: this.alg,
           issuer: this.issuer,

--- a/packages/client/lib/__tests__/SdJwt.spec.ts
+++ b/packages/client/lib/__tests__/SdJwt.spec.ts
@@ -129,7 +129,15 @@ describe('sd-jwt vc', () => {
         .reply(200, async (_, body) =>
           vcIssuer.issueCredential({
             credentialRequest: body as CredentialRequestV1_0_11,
-            credential: {} as any, // TODO: define the interface for credential when using sd-jwt
+            credential: {
+              vct: 'Hello',
+              iss: 'did:example:123',
+              iat: 123,
+              // Defines what can be disclosed (optional)
+              __disclosureFrame: {
+                name: true,
+              },
+            },
             newCNonce: 'new-c-nonce',
           }),
         );

--- a/packages/client/lib/__tests__/SdJwt.spec.ts
+++ b/packages/client/lib/__tests__/SdJwt.spec.ts
@@ -15,9 +15,7 @@ const issuerMetadata = new IssuerMetadataBuilderV1_11()
   .withTokenEndpoint('https://token-endpoint.example.com')
   .addSupportedCredential({
     format: 'vc+sd-jwt',
-    credential_definition: {
-      vct: 'SdJwtCredential',
-    },
+    vct: 'SdJwtCredential',
     id: 'SdJwtCredentialId',
   })
   .build();
@@ -98,9 +96,7 @@ describe('sd-jwt vc', () => {
       const supported = client.getCredentialsSupported(true, 'vc+sd-jwt');
       expect(supported).toEqual([
         {
-          credential_definition: {
-            vct: 'SdJwtCredential',
-          },
+          vct: 'SdJwtCredential',
           format: 'vc+sd-jwt',
           id: 'SdJwtCredentialId',
         },
@@ -143,7 +139,7 @@ describe('sd-jwt vc', () => {
         );
 
       const credentials = await client.acquireCredentials({
-        credentialTypes: [offered.credential_definition.vct],
+        credentialTypes: [offered.vct],
         format: 'vc+sd-jwt',
         alg,
         jwk,
@@ -156,7 +152,7 @@ describe('sd-jwt vc', () => {
       expect(credentials).toEqual({
         c_nonce: 'new-c-nonce',
         c_nonce_expires_in: 300000,
-        credential: 'sd-jwt', // TODO: make this a real sd-jwt vc
+        credential: 'sd-jwt',
         format: 'vc+sd-jwt',
       });
     },

--- a/packages/client/lib/__tests__/SdJwt.spec.ts
+++ b/packages/client/lib/__tests__/SdJwt.spec.ts
@@ -1,0 +1,157 @@
+import { AccessTokenRequest, CredentialRequestV1_0_11, CredentialSupportedSdJwtVc } from '@sphereon/oid4vci-common';
+import nock from 'nock';
+
+import { OpenID4VCIClient } from '..';
+import { createAccessTokenResponse, IssuerMetadataBuilderV1_11, VcIssuerBuilder } from '../../../issuer';
+
+export const UNIT_TEST_TIMEOUT = 30000;
+
+const alg = 'ES256';
+const jwk = { kty: 'EC', crv: 'P-256', x: 'zQOowIC1gWJtdddB5GAt4lau6Lt8Ihy771iAfam-1pc', y: 'cjD_7o3gdQ1vgiQy3_sMGs7WrwCMU9FQYimA3HxnMlw' };
+
+const issuerMetadata = new IssuerMetadataBuilderV1_11()
+  .withCredentialIssuer('https://example.com')
+  .withCredentialEndpoint('https://credenital-endpoint.example.com')
+  .withTokenEndpoint('https://token-endpoint.example.com')
+  .addSupportedCredential({
+    format: 'vc+sd-jwt',
+    credential_definition: {
+      vct: 'SdJwtCredential',
+    },
+    id: 'SdJwtCredentialId',
+  })
+  .build();
+
+const vcIssuer = new VcIssuerBuilder()
+  .withIssuerMetadata(issuerMetadata)
+  .withInMemoryCNonceState()
+  .withInMemoryCredentialOfferState()
+  .withInMemoryCredentialOfferURIState()
+  // TODO: see if we can construct an sd-jwt vc based on the input
+  .withCredentialSignerCallback(async () => {
+    return 'sd-jwt';
+  })
+  .withJWTVerifyCallback(() =>
+    Promise.resolve({
+      alg,
+      jwk,
+      jwt: {
+        header: {
+          typ: 'openid4vci-proof+jwt',
+          alg,
+          jwk,
+        },
+        payload: {
+          aud: issuerMetadata.credential_issuer,
+          iat: +new Date(),
+          nonce: 'a-c-nonce',
+        },
+      },
+    }),
+  )
+  .build();
+
+describe('sd-jwt vc', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it(
+    'succeed with a full flow',
+    async () => {
+      const offerUri = await vcIssuer.createCredentialOfferURI({
+        grants: {
+          'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
+            'pre-authorized_code': '123',
+            user_pin_required: false,
+          },
+        },
+        credentials: ['SdJwtCredentialId'],
+      });
+
+      nock(vcIssuer.issuerMetadata.credential_issuer).get('/.well-known/openid-credential-issuer').reply(200, JSON.stringify(issuerMetadata));
+      nock(vcIssuer.issuerMetadata.credential_issuer).get('/.well-known/openid-configuration').reply(404);
+      nock(vcIssuer.issuerMetadata.credential_issuer).get('/.well-known/oauth-authorization-server').reply(404);
+
+      expect(offerUri.uri).toEqual(
+        'openid-credential-offer://?credential_offer=%7B%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22123%22%2C%22user_pin_required%22%3Afalse%7D%7D%2C%22credentials%22%3A%5B%22SdJwtCredentialId%22%5D%2C%22credential_issuer%22%3A%22https%3A%2F%2Fexample.com%22%7D',
+      );
+
+      const client = await OpenID4VCIClient.fromURI({
+        uri: offerUri.uri,
+      });
+
+      expect(client.credentialOffer.credential_offer).toEqual({
+        credential_issuer: 'https://example.com',
+        credentials: ['SdJwtCredentialId'],
+        grants: {
+          'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
+            'pre-authorized_code': '123',
+            user_pin_required: false,
+          },
+        },
+      });
+
+      const supported = client.getCredentialsSupported(true, 'vc+sd-jwt');
+      expect(supported).toEqual([
+        {
+          credential_definition: {
+            vct: 'SdJwtCredential',
+          },
+          format: 'vc+sd-jwt',
+          id: 'SdJwtCredentialId',
+        },
+      ]);
+
+      const offered = supported[0] as CredentialSupportedSdJwtVc;
+
+      nock(issuerMetadata.token_endpoint as string)
+        .post('/')
+        .reply(200, async (_, body: string) => {
+          const parsedBody = Object.fromEntries(body.split('&').map((x) => x.split('=')));
+          return createAccessTokenResponse(parsedBody as AccessTokenRequest, {
+            credentialOfferSessions: vcIssuer.credentialOfferSessions,
+            accessTokenIssuer: 'https://issuer.example.com',
+            cNonces: vcIssuer.cNonces,
+            cNonce: 'a-c-nonce',
+            accessTokenSignerCallback: async () => 'ey.val.ue',
+            tokenExpiresIn: 500,
+          });
+        });
+
+      await client.acquireAccessToken({});
+
+      nock(issuerMetadata.credential_endpoint as string)
+        .post('/')
+        .reply(200, async (_, body) =>
+          vcIssuer.issueCredential({
+            credentialRequest: body as CredentialRequestV1_0_11,
+            credential: {} as any, // TODO: define the interface for credential when using sd-jwt
+            newCNonce: 'new-c-nonce',
+          }),
+        );
+
+      const credentials = await client.acquireCredentials({
+        credentialTypes: [offered.credential_definition.vct],
+        format: 'vc+sd-jwt',
+        alg,
+        jwk,
+        proofCallbacks: {
+          // When using sd-jwt for real, this jwt should include a jwk
+          signCallback: async () => 'ey.ja.ja',
+        },
+      });
+
+      expect(credentials).toEqual({
+        c_nonce: 'new-c-nonce',
+        c_nonce_expires_in: 300000,
+        credential: 'sd-jwt', // TODO: make this a real sd-jwt vc
+        format: 'vc+sd-jwt',
+      });
+    },
+    UNIT_TEST_TIMEOUT,
+  );
+});

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@sphereon/oid4vci-common": "workspace:*",
-    "@sphereon/ssi-types": "0.17.2",
+    "@sphereon/ssi-types": "0.17.6-unstable.69",
     "cross-fetch": "^3.1.8",
     "debug": "^4.3.4"
   },

--- a/packages/common/lib/functions/CredentialOfferUtil.ts
+++ b/packages/common/lib/functions/CredentialOfferUtil.ts
@@ -353,7 +353,7 @@ export function getTypesFromOffer(credentialOffer: UniformCredentialOfferPayload
     } else if (curr.format === 'jwt_vc_json') {
       return [...prev, ...curr.types];
     } else if (curr.format === 'vc+sd-jwt') {
-      return [...prev, curr.credential_definition.vct];
+      return [...prev, curr.vct];
     }
 
     return prev;

--- a/packages/common/lib/functions/CredentialRequestUtil.ts
+++ b/packages/common/lib/functions/CredentialRequestUtil.ts
@@ -9,7 +9,7 @@ export function getTypesFromRequest(credentialRequest: UniformCredentialRequest,
   } else if (credentialRequest.format === 'jwt_vc_json-ld' || credentialRequest.format === 'ldp_vc') {
     types = credentialRequest.credential_definition.types;
   } else if (credentialRequest.format === 'vc+sd-jwt') {
-    types = [credentialRequest.credential_definition.vct];
+    types = [credentialRequest.vct];
   }
 
   if (!types || types.length === 0) {

--- a/packages/common/lib/functions/IssuerMetadataUtils.ts
+++ b/packages/common/lib/functions/IssuerMetadataUtils.ts
@@ -104,7 +104,7 @@ export function getTypesFromCredentialSupported(credentialSupported: CredentialS
   if (credentialSupported.format === 'jwt_vc_json' || credentialSupported.format === 'jwt_vc_json-ld' || credentialSupported.format === 'ldp_vc') {
     types = credentialSupported.types;
   } else if (credentialSupported.format === 'vc+sd-jwt') {
-    types = [credentialSupported.credential_definition.vct];
+    types = [credentialSupported.vct];
   }
 
   if (!types || types.length === 0) {

--- a/packages/common/lib/types/Authorization.types.ts
+++ b/packages/common/lib/types/Authorization.types.ts
@@ -5,7 +5,6 @@ import {
   JsonLdIssuerCredentialDefinition,
   OID4VCICredentialFormat,
   PRE_AUTH_CODE_LITERAL,
-  SdJwtVcCredentialDefinition,
 } from './Generic.types';
 import { EndpointMetadata } from './ServerMetadata';
 
@@ -140,7 +139,8 @@ export interface AuthorizationDetailsJwtVcJsonLdAndLdpVc extends CommonAuthoriza
 export interface AuthorizationDetailsSdJwtVc extends CommonAuthorizationDetails {
   format: 'vc+sd-jwt';
 
-  credential_definition: SdJwtVcCredentialDefinition;
+  vct: string;
+  claims?: IssuerCredentialSubject;
 }
 
 export enum GrantTypes {

--- a/packages/common/lib/types/Generic.types.ts
+++ b/packages/common/lib/types/Generic.types.ts
@@ -90,16 +90,12 @@ export interface CredentialSupportedJwtVcJson extends CommonCredentialSupported 
   format: 'jwt_vc_json';
 }
 
-export interface SdJwtVcCredentialDefinition {
-  vct: string; // REQUIRED. JSON string designating the type of an SD-JWT vc
-  claims?: IssuerCredentialSubject;
-}
-
 export interface CredentialSupportedSdJwtVc extends CommonCredentialSupported {
   format: 'vc+sd-jwt';
 
-  // REQUIRED. JSON object containing the detailed description of the credential type
-  credential_definition: SdJwtVcCredentialDefinition;
+  vct: string;
+  claims?: IssuerCredentialSubject;
+
   order?: string[]; //An array of claims.display.name values that lists them in the order they should be displayed by the Wallet.
 }
 
@@ -121,9 +117,14 @@ export interface CredentialOfferFormatJwtVcJson extends CommonCredentialOfferFor
   types: string[]; // REQUIRED. JSON array as defined in Appendix E.1.1.2. This claim contains the type values the Wallet shall request in the subsequent Credential Request.
 }
 
+// NOTE: the sd-jwt format is added to oid4vci in a later draft version than currently
+// supported, so there's no defined offer format. However, based on the request structure
+// we support sd-jwt for older drafts of oid4vci as well
 export interface CredentialOfferFormatSdJwtVc extends CommonCredentialOfferFormat {
   format: 'vc+sd-jwt';
-  credential_definition: SdJwtVcCredentialDefinition;
+
+  vct: string;
+  claims?: IssuerCredentialSubject;
 }
 
 export type CredentialOfferFormat = CommonCredentialOfferFormat &
@@ -176,7 +177,8 @@ export interface CredentialRequestJwtVcJsonLdAndLdpVc extends CommonCredentialRe
 
 export interface CredentialRequestSdJwtVc extends CommonCredentialRequest {
   format: 'vc+sd-jwt';
-  credential_definition: SdJwtVcCredentialDefinition;
+  vct: string;
+  claims?: IssuerCredentialSubject;
 }
 
 export interface CommonCredentialResponse {

--- a/packages/common/lib/types/QRCode.types.ts
+++ b/packages/common/lib/types/QRCode.types.ts
@@ -60,7 +60,7 @@ export interface ComponentOptions {
      */
     protectors?: boolean;
   };
-};
+}
 
 export interface QRCodeOpts {
   /**
@@ -224,4 +224,4 @@ export interface QRCodeOpts {
    * @deafultValue 0.4
    */
   dotScale?: number;
-};
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,7 +10,7 @@
     "build:clean": "tsc --build --clean && tsc --build"
   },
   "dependencies": {
-    "@sphereon/ssi-types": "0.17.2",
+    "@sphereon/ssi-types": "0.17.6-unstable.69",
     "cross-fetch": "^3.1.8",
     "jwt-decode": "^3.1.2"
   },

--- a/packages/issuer-rest/package.json
+++ b/packages/issuer-rest/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@sphereon/oid4vci-common": "workspace:*",
     "@sphereon/oid4vci-issuer": "workspace:*",
-    "@sphereon/ssi-express-support": "0.17.2",
-    "@sphereon/ssi-types": "0.17.2",
+    "@sphereon/ssi-express-support": "0.17.6-unstable.69",
+    "@sphereon/ssi-types": "0.17.6-unstable.69",
     "body-parser": "^1.20.2",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -404,7 +404,7 @@ export class VcIssuer<DIDDoc extends object> {
     let preAuthorizedCode: string | undefined
     let issuerState: string | undefined
     try {
-      if (credentialRequest.format !== 'jwt_vc_json' && credentialRequest.format !== 'jwt_vc_json-ld') {
+      if (credentialRequest.format !== 'jwt_vc_json' && credentialRequest.format !== 'jwt_vc_json-ld' && credentialRequest.format !== 'vc+sd-jwt') {
         throw Error(`Format ${credentialRequest.format} not supported yet`)
       } else if (typeof this._jwtVerifyCallback !== 'function' && typeof jwtVerifyCallback !== 'function') {
         throw new Error(JWT_VERIFY_CONFIG_ERROR)

--- a/packages/issuer/lib/builder/CredentialSupportedBuilderV1_11.ts
+++ b/packages/issuer/lib/builder/CredentialSupportedBuilderV1_11.ts
@@ -125,9 +125,7 @@ export class CredentialSupportedBuilderV1_11 {
       if (this.types.length > 1) {
         throw new Error('Only one type is allowed for vc+sd-jwt')
       }
-      credentialSupported.credential_definition = {
-        vct: this.types[0],
-      }
+      credentialSupported.vct = this.types[0]
     }
     // And else would work here, but this way we get the correct typing
     else if (isNotFormat(credentialSupported, 'vc+sd-jwt')) {

--- a/packages/issuer/lib/types/index.ts
+++ b/packages/issuer/lib/types/index.ts
@@ -7,11 +7,11 @@ import {
   OID4VCICredentialFormat,
   UniformCredentialRequest,
 } from '@sphereon/oid4vci-common'
-import { ICredential, W3CVerifiableCredential } from '@sphereon/ssi-types'
+import { ICredential, SdJwtDecodedVerifiableCredentialPayload, SdJwtDisclosureFrame, W3CVerifiableCredential } from '@sphereon/ssi-types'
 
 export type CredentialSignerCallback<T extends object> = (opts: {
   credentialRequest: UniformCredentialRequest
-  credential: ICredential
+  credential: CredentialIssuanceInput
   format?: OID4VCICredentialFormat
   /**
    * We use object since we don't want to expose the DID Document TS type to too many interfaces.
@@ -28,8 +28,10 @@ export interface CredentialDataSupplierArgs extends CNonceState {
   credentialDataSupplierInput?: CredentialDataSupplierInput
 }
 
+export type CredentialIssuanceInput = ICredential | (SdJwtDecodedVerifiableCredentialPayload & { __disclosureFrame?: SdJwtDisclosureFrame })
+
 export interface CredentialDataSupplierResult {
-  credential: ICredential
+  credential: CredentialIssuanceInput
   format?: OID4VCICredentialFormat
   signCallback?: CredentialSignerCallback<any> // If the data supplier wants to actually sign directly
 }

--- a/packages/issuer/package.json
+++ b/packages/issuer/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@sphereon/oid4vci-common": "workspace:*",
-    "@sphereon/ssi-types": "0.17.2",
+    "@sphereon/ssi-types": "0.17.6-unstable.69",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: workspace:*
         version: link:../issuer
       '@sphereon/ssi-types':
-        specifier: 0.17.2
-        version: 0.17.2
+        specifier: 0.17.6-unstable.69
+        version: 0.17.6-unstable.69
       jose:
         specifier: ^4.10.0
         version: 4.14.6
@@ -118,8 +118,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@sphereon/ssi-types':
-        specifier: 0.17.2
-        version: 0.17.2
+        specifier: 0.17.6-unstable.69
+        version: 0.17.6-unstable.69
       cross-fetch:
         specifier: ^3.1.8
         version: 3.1.8
@@ -200,8 +200,8 @@ importers:
   packages/common:
     dependencies:
       '@sphereon/ssi-types':
-        specifier: 0.17.2
-        version: 0.17.2
+        specifier: 0.17.6-unstable.69
+        version: 0.17.6-unstable.69
       cross-fetch:
         specifier: ^3.1.8
         version: 3.1.8
@@ -222,8 +222,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@sphereon/ssi-types':
-        specifier: 0.17.2
-        version: 0.17.2
+        specifier: 0.17.6-unstable.69
+        version: 0.17.6-unstable.69
       awesome-qr:
         specifier: ^2.1.5-rc.0
         version: 2.1.5-rc.0
@@ -256,11 +256,11 @@ importers:
         specifier: workspace:*
         version: link:../issuer
       '@sphereon/ssi-express-support':
-        specifier: 0.17.2
-        version: 0.17.2
+        specifier: 0.17.6-unstable.69
+        version: 0.17.6-unstable.69
       '@sphereon/ssi-types':
-        specifier: 0.17.2
-        version: 0.17.2
+        specifier: 0.17.6-unstable.69
+        version: 0.17.6-unstable.69
       body-parser:
         specifier: ^1.20.2
         version: 1.20.2
@@ -3349,6 +3349,12 @@ packages:
   /@react-native/polyfills@2.0.0:
     resolution: {integrity: sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==}
 
+  /@sd-jwt/core@0.1.2-alpha.0:
+    resolution: {integrity: sha512-x4MVXar6WmPauZDRJ3aHwaY8o/bHzN77Ts7o43JKuuqIBFjPgAcSlRtd/Xk1rWhazFai4MCIwJDSQ1OQRJtNug==}
+    dependencies:
+      buffer: 6.0.3
+    dev: false
+
   /@segment/loosely-validate-event@2.0.0:
     resolution: {integrity: sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==}
     dependencies:
@@ -3412,8 +3418,8 @@ packages:
     dependencies:
       '@sinonjs/commons': 3.0.0
 
-  /@sphereon/ssi-express-support@0.17.2:
-    resolution: {integrity: sha512-OrLC7YAelpUmCIzPRgHM97HBNFqDoSdJNNssstS6Ho0ZXswq4fsPDm+h49+//ogp1ERbuOl9Ywqhp+3DdLZCPA==}
+  /@sphereon/ssi-express-support@0.17.6-unstable.69:
+    resolution: {integrity: sha512-IpiiW6KPv5zjvlCCxyw4S093WL4na6zvJjoWI26te04Y4T1yYF3FfaGdcA+BAQl4URvvcp09mzay2Z8RwmDLSA==}
     peerDependencies:
       '@noble/hashes': 1.2.0
       passport-azure-ad: ^4.3.5
@@ -3443,9 +3449,10 @@ packages:
       - supports-color
     dev: false
 
-  /@sphereon/ssi-types@0.17.2:
-    resolution: {integrity: sha512-Qo1dkISavtPIe1WKZXZGyHvquoUvdUlDI0GLzb21clKFPuxbawXdlxpCqOh6NCNRfX7ohEeCUQdEA1PNBlnKYA==}
+  /@sphereon/ssi-types@0.17.6-unstable.69:
+    resolution: {integrity: sha512-VwjVd6XhoV5QecWcRh0RpBf5N324tfhYcQrVk9se3brqMNMauZTBbhUhk+QLdwFd+u/1+IfEWnS28HyIU7lXHQ==}
     dependencies:
+      '@sd-jwt/core': 0.1.2-alpha.0
       jwt-decode: 3.1.2
     dev: false
 
@@ -4964,7 +4971,7 @@ packages:
       minipass-pipeline: 1.2.4
       p-map: 4.0.0
       ssri: 10.0.5
-      tar: 6.2.0
+      tar: 6.1.11
       unique-filename: 3.0.0
     dev: true
 
@@ -10044,7 +10051,7 @@ packages:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.5.4
-      tar: 6.2.0
+      tar: 6.1.11
       which: 2.0.2
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
This PR builds on top of https://github.com/Sphereon-Opensource/OID4VCI/pull/78, and adds support for issuance side for sd-jwt vcs as well as adds an e2e test using sd-jwt vcs

It's not fully complete yet, as I need to define the `credential` interface that is passed as input to the issueCredential. Sd JWT VCs have a different interface than the other credential types, and need to make sure the right data is passed.

An alternative I was thinking of, is whether it may be possible to just pass in a signed credential, and not use the `signedCallback` etc..

That way we can create a SD-JWT VC based on the request, and then pass it to issue credential directly (which will do the other validations)

